### PR TITLE
Bring tests uptodate for newer PHPUnit.

### DIFF
--- a/tests/judgerequestemail_test.php
+++ b/tests/judgerequestemail_test.php
@@ -35,7 +35,7 @@ class assignsubmission_comparativejudgement_judgerequestemail_testcase extends a
     // Use the generator helper.
     use mod_assign_test_generator;
 
-    public function setUp() {
+    public function setUp() :void {
         global $CFG;
 
         $CFG->enablecompletion = true;


### PR DESCRIPTION
Newer versions of PHPUnit fail with an exception without this update.